### PR TITLE
Add Docker quick start and container-safe Whisper local routing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.gitignore
+node_modules
+.pnpm-store
+apps/web/.next
+apps/web/.env.local
+apps/web/.env.*
+build
+tmp
+**/__pycache__
+**/*.pyc
+local-only/openscribe-backend/.venv-backend
+.venv-med
+recordings

--- a/README.md
+++ b/README.md
@@ -91,6 +91,40 @@ Optional desktop app path:
 pnpm electron:dev
 ```
 
+## Quick Start (Docker)
+
+SAM is the easiest way to run OpenScribe for new contributors: one command starts the web app and local Whisper transcription service.
+
+### 1. Create SAM env file
+
+```bash
+pnpm run setup
+```
+
+Edit `apps/web/.env.local` and set:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-YOUR_KEY_HERE
+```
+
+### 2. Start SAM
+
+```bash
+docker compose -f docker-compose.sam.yml up --build
+```
+
+### 3. Open the app
+
+```bash
+http://localhost:3001
+```
+
+### 4. Verify Whisper health (optional)
+
+```bash
+curl http://127.0.0.1:8002/health
+```
+
 ---
 
 ## Runtime Modes

--- a/config/scripts/check-structure.mjs
+++ b/config/scripts/check-structure.mjs
@@ -6,7 +6,7 @@ import path from "node:path"
 
 const root = path.resolve(process.cwd())
 
-const allowedRootDirs = new Set(["apps", "packages", "config", "build", "node_modules"])
+const allowedRootDirs = new Set(["apps", "packages", "config", "build", "docker", "node_modules"])
 const allowedRootFiles = new Set([
   "package.json",
   "pnpm-lock.yaml",
@@ -19,6 +19,8 @@ const allowedRootFiles = new Set([
   "QUICK_START.md",
   "STABILITY_FIXES.md",
   "TEST_SESSION.md",
+  ".dockerignore",
+  "docker-compose.sam.yml",
 ])
 const buildArtifacts = new Set([".next", ".tests-dist", "dist"])
 const configPattern = /\.config\.(?:js|cjs|mjs|ts)$/

--- a/docker-compose.sam.yml
+++ b/docker-compose.sam.yml
@@ -1,0 +1,40 @@
+services:
+  sam-whisper:
+    build:
+      context: .
+      dockerfile: docker/whisper.Dockerfile
+    container_name: sam-whisper
+    env_file:
+      - apps/web/.env.local
+    ports:
+      - "8002:8002"
+    volumes:
+      - sam-whisper-cache:/root/.cache
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8002/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+
+  sam-web:
+    build:
+      context: .
+      dockerfile: docker/web.Dockerfile
+    container_name: sam-web
+    depends_on:
+      sam-whisper:
+        condition: service_healthy
+    env_file:
+      - apps/web/.env.local
+    environment:
+      NODE_ENV: development
+      TRANSCRIPTION_PROVIDER: whisper_local
+      WHISPER_LOCAL_URL: http://sam-whisper:8002/v1/audio/transcriptions
+      WHISPER_LOCAL_TRUSTED_HOSTS: sam-whisper
+    ports:
+      - "3001:3001"
+    command: ["pnpm", "exec", "next", "dev", "apps/web", "--webpack", "-p", "3001", "-H", "0.0.0.0"]
+
+volumes:
+  sam-whisper-cache:

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-bookworm-slim
+
+WORKDIR /app
+
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml tsconfig.json ./
+COPY config ./config
+COPY apps ./apps
+COPY packages ./packages
+COPY scripts ./scripts
+COPY local-only ./local-only
+
+RUN pnpm install --frozen-lockfile
+
+EXPOSE 3001

--- a/docker/whisper.Dockerfile
+++ b/docker/whisper.Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg curl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY scripts ./scripts
+COPY local-only/openscribe-backend/src ./local-only/openscribe-backend/src
+
+RUN python -m pip install --no-cache-dir --upgrade pip \
+  && python -m pip install --no-cache-dir pywhispercpp fastapi "uvicorn[standard]" python-multipart
+
+EXPOSE 8002
+
+CMD ["python", "scripts/whisper_server.py", "--host", "0.0.0.0", "--port", "8002", "--model", "tiny.en", "--backend", "cpp"]

--- a/packages/pipeline/transcribe/src/providers/whisper-local-transcriber.ts
+++ b/packages/pipeline/transcribe/src/providers/whisper-local-transcriber.ts
@@ -24,10 +24,15 @@ function validateLocalOrHttpsUrl(url: string, serviceName: string): void {
   try {
     const parsed = new URL(url)
     const isLocalhost = parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1" || parsed.hostname === "::1"
+    const trustedHosts = (process.env.WHISPER_LOCAL_TRUSTED_HOSTS || "")
+      .split(",")
+      .map((host) => host.trim().toLowerCase())
+      .filter(Boolean)
+    const isTrustedHost = trustedHosts.includes(parsed.hostname.toLowerCase())
 
-    if (!isLocalhost && parsed.protocol !== "https:") {
+    if (!isLocalhost && !isTrustedHost && parsed.protocol !== "https:") {
       throw new Error(
-        `SECURITY ERROR: ${serviceName} endpoint must use HTTPS or localhost. ` +
+        `SECURITY ERROR: ${serviceName} endpoint must use HTTPS, localhost, or a host listed in WHISPER_LOCAL_TRUSTED_HOSTS. ` +
           `Received: ${parsed.protocol}//${parsed.host}`,
       )
     }


### PR DESCRIPTION
## Summary
- add Docker quick start for local web + whisper services
- add docker compose and service Dockerfiles
- update README quick start instructions
- allow trusted internal host for whisper local URL validation in containerized setups

## Testing
- docker compose build/up
- whisper health endpoint
- transcription final/segment API route checks
- browser automation smoke flow